### PR TITLE
fix role dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,4 +20,4 @@ galaxy_info:
     - system
 
 dependencies:
-  - zerodowntime.dns_tools
+  []


### PR DESCRIPTION
the requested role is not publicly available.
It seems to work well enough without it.

https://github.com/zerodowntime/ansible-role-bind9/issues/1